### PR TITLE
Update Gnome runtime to version 46

### DIFF
--- a/de.willuhn.Jameica.yaml
+++ b/de.willuhn.Jameica.yaml
@@ -1,7 +1,7 @@
 app-id: de.willuhn.Jameica
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17


### PR DESCRIPTION
Update to latest Gnome runtime. The previous used version 44 is outdated since March 2024